### PR TITLE
Typo: original -> lst

### DIFF
--- a/scheme/lists/accessing.md
+++ b/scheme/lists/accessing.md
@@ -120,7 +120,7 @@ colloquially be expressed much clearer as the “number of retrieved elements”
 If an actual sub-list is required the procedures can be stacked/nested:
 
 ```
-guile> (list-head (list-tail original 2) 2)
+guile> (list-head (list-tail lst 2) 2)
 (3 4)
 ```
 


### PR DESCRIPTION
Hello Urs,

A google search made me find the github repository that I could fork and correct for another minor typo. If it's ok for you, I will continue to read your book and correct typo as I see some of them. 
Here, there should have been a previous version where you called the liste `original` rather than `lst` I presume.

Cheers,

JJ